### PR TITLE
Add customer totals to dashboard

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from PySide6.QtWidgets import QListWidget, QVBoxLayout, QWidget, QLabel
+from PySide6.QtWidgets import QListWidget, QVBoxLayout, QWidget, QLabel, QFrame
 
 import database
 
@@ -18,11 +18,25 @@ class DashboardPage(QWidget):
     def _create_ui(self) -> None:
         layout = QVBoxLayout(self)
 
-        title = QLabel("Upcoming Appointments")
-        title.setStyleSheet("font-weight: bold; font-size: 16px;")
-        self.list_widget = QListWidget()
+        header = QLabel("Dashboard")
+        header.setStyleSheet(
+            "font-weight: bold; font-size: 24px; padding: 4px; margin-bottom: 8px;"
+        )
 
-        layout.addWidget(title)
+        self.total_label = QLabel()
+        self.total_label.setStyleSheet("font-size: 18px; color: #007acc; margin: 4px 0;")
+
+        upcoming_title = QLabel("Upcoming Appointments")
+        upcoming_title.setStyleSheet(
+            "font-weight: bold; font-size: 16px; margin-top: 12px;"
+        )
+
+        self.list_widget = QListWidget()
+        self.list_widget.setFrameShape(QFrame.NoFrame)
+
+        layout.addWidget(header)
+        layout.addWidget(self.total_label)
+        layout.addWidget(upcoming_title)
         layout.addWidget(self.list_widget)
         layout.addStretch()
 
@@ -30,6 +44,8 @@ class DashboardPage(QWidget):
         """Load appointments from the database into the list widget."""
         self.list_widget.clear()
         appointments = database.get_upcoming_appointments()
+        total_customers = database.get_total_customers()
+        self.total_label.setText(f"Total Customers: {total_customers}")
         if not appointments:
             self.list_widget.addItem("No upcoming appointments.")
             return

--- a/database.py
+++ b/database.py
@@ -115,6 +115,16 @@ def get_upcoming_appointments(limit: int = 5) -> Iterable[sqlite3.Row]:
     return rows
 
 
+def get_total_customers() -> int:
+    """Return the number of unique customers based on appointments."""
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(DISTINCT patient_name) AS count FROM appointments")
+    row = cur.fetchone()
+    conn.close()
+    return row["count"] if row else 0
+
+
 def export_database(target_path: str | Path) -> None:
     """Copy the database file to ``target_path``."""
     shutil.copy(DB_FILE, target_path)
@@ -131,6 +141,7 @@ __all__ = [
     "get_doctor_info",
     "save_doctor_info",
     "get_upcoming_appointments",
+    "get_total_customers",
     "export_database",
     "import_database",
 ]


### PR DESCRIPTION
## Summary
- count unique customers in the database
- display total customers in the dashboard
- improve dashboard layout styling

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685edf2504f88322a083208613536a27