### PR TITLE
Expand customer management with therapy tracking

### DIFF
--- a/customer_dialog.py
+++ b/customer_dialog.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QFormLayout,
+    QLineEdit,
+    QTextEdit,
+    QPushButton,
+    QLabel,
+    QDateEdit,
+    QTabWidget,
+    QTableWidget,
+    QTableWidgetItem,
+    QWidget,
+)
+from PySide6.QtCore import QDate
+
+import database
+
+
+class TherapyDialog(QDialog):
+    """Dialog to add or edit a therapy entry."""
+
+    def __init__(self, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Therapy")
+        form = QFormLayout(self)
+        self.date_edit = QDateEdit(QDate.currentDate())
+        self.date_edit.setCalendarPopup(True)
+        self.tooth_edit = QLineEdit()
+        self.desc_edit = QLineEdit()
+        self.payment_edit = QLineEdit("0")
+        self.cost_edit = QLineEdit("0")
+        self.discount_edit = QLineEdit("0")
+        self.comment_edit = QLineEdit()
+        form.addRow("Date", self.date_edit)
+        form.addRow("Tooth", self.tooth_edit)
+        form.addRow("Description", self.desc_edit)
+        form.addRow("Payment", self.payment_edit)
+        form.addRow("Cost", self.cost_edit)
+        form.addRow("Discount", self.discount_edit)
+        form.addRow("Comment", self.comment_edit)
+        btn_row = QHBoxLayout()
+        ok_btn = QPushButton("OK")
+        ok_btn.clicked.connect(self.accept)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(ok_btn)
+        btn_row.addWidget(cancel_btn)
+        form.addRow(btn_row)
+
+    def data(self) -> dict:
+        return {
+            "visit_date": self.date_edit.date().toString("yyyy-MM-dd"),
+            "tooth": self.tooth_edit.text(),
+            "description": self.desc_edit.text(),
+            "payment": float(self.payment_edit.text() or 0),
+            "cost": float(self.cost_edit.text() or 0),
+            "discount": float(self.discount_edit.text() or 0),
+            "comment": self.comment_edit.text(),
+        }
+
+
+class CustomerDialog(QDialog):
+    """Dialog for adding/editing a customer with therapy data."""
+
+    def __init__(self, data: dict | None = None, parent: QDialog | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Customer")
+        self._create_ui()
+        if data:
+            self.load_data(data)
+
+    def _create_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+        # Personal tab
+        personal = QWidget()
+        form = QFormLayout(personal)
+        self.first_edit = QLineEdit()
+        self.last_edit = QLineEdit()
+        self.birth_edit = QDateEdit()
+        self.birth_edit.setCalendarPopup(True)
+        self.age_label = QLabel()
+        self.birth_edit.dateChanged.connect(self._update_age)
+        self.address_edit = QLineEdit()
+        self.phone_edit = QLineEdit()
+        self.register_edit = QDateEdit(QDate.currentDate())
+        self.register_edit.setCalendarPopup(True)
+        self.last_visit_edit = QDateEdit(QDate.currentDate())
+        self.last_visit_edit.setCalendarPopup(True)
+        self.referral_edit = QLineEdit()
+        self.med_history = QTextEdit()
+        self.extra_info = QTextEdit()
+        form.addRow("First Name", self.first_edit)
+        form.addRow("Last Name", self.last_edit)
+        row = QHBoxLayout()
+        row.addWidget(self.birth_edit)
+        row.addWidget(self.age_label)
+        form.addRow("Birth Date", row)
+        form.addRow("Address", self.address_edit)
+        form.addRow("Telephone", self.phone_edit)
+        form.addRow("Register Date", self.register_edit)
+        form.addRow("Last Visit", self.last_visit_edit)
+        form.addRow("Referral", self.referral_edit)
+        form.addRow("Medical History", self.med_history)
+        form.addRow("Extra Info", self.extra_info)
+        self.tabs.addTab(personal, "Personal Details")
+        # Therapy tab
+        therapy_tab = QWidget()
+        t_layout = QVBoxLayout(therapy_tab)
+        self.therapy_table = QTableWidget(0, 7)
+        self.therapy_table.setHorizontalHeaderLabels([
+            "Date", "Tooth", "Description", "Payment", "Cost", "Discount", "Comment"
+        ])
+        t_layout.addWidget(self.therapy_table)
+        add_btn = QPushButton("Add Entry")
+        add_btn.clicked.connect(self.add_therapy)
+        t_layout.addWidget(add_btn)
+        self.total_label = QLabel()
+        t_layout.addWidget(self.total_label)
+        self.tabs.addTab(therapy_tab, "Therapy")
+        # Buttons
+        btn_row = QHBoxLayout()
+        save_btn = QPushButton("Save")
+        save_btn.clicked.connect(self.accept)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        btn_row.addStretch()
+        btn_row.addWidget(save_btn)
+        btn_row.addWidget(cancel_btn)
+        layout.addLayout(btn_row)
+
+    def _update_age(self) -> None:
+        bdate = self.birth_edit.date()
+        years = bdate.daysTo(QDate.currentDate()) // 365
+        self.age_label.setText(f"- {years} years old")
+
+    def add_therapy(self) -> None:
+        dlg = TherapyDialog(self)
+        if dlg.exec() == QDialog.Accepted:
+            data = dlg.data()
+            r = self.therapy_table.rowCount()
+            self.therapy_table.insertRow(r)
+            for c, key in enumerate(["visit_date", "tooth", "description", "payment", "cost", "discount", "comment"]):
+                self.therapy_table.setItem(r, c, QTableWidgetItem(str(data[key])))
+            self._update_totals()
+
+    def _update_totals(self) -> None:
+        payments = costs = discounts = 0.0
+        for r in range(self.therapy_table.rowCount()):
+            payments += float(self.therapy_table.item(r, 3).text())
+            costs += float(self.therapy_table.item(r, 4).text())
+            discounts += float(self.therapy_table.item(r, 5).text())
+        owe = costs - payments - discounts
+        self.total_label.setText(
+            f"Payments: {payments}  Costs: {costs}  Discounts: {discounts}  Owe: {owe}"
+        )
+
+    def data(self) -> dict:
+        therapies = []
+        for r in range(self.therapy_table.rowCount()):
+            row = {
+                "visit_date": self.therapy_table.item(r, 0).text(),
+                "tooth": self.therapy_table.item(r, 1).text(),
+                "description": self.therapy_table.item(r, 2).text(),
+                "payment": float(self.therapy_table.item(r, 3).text()),
+                "cost": float(self.therapy_table.item(r, 4).text()),
+                "discount": float(self.therapy_table.item(r, 5).text()),
+                "comment": self.therapy_table.item(r, 6).text(),
+            }
+            therapies.append(row)
+        return {
+            "first_name": self.first_edit.text(),
+            "last_name": self.last_edit.text(),
+            "birth_date": self.birth_edit.date().toString("yyyy-MM-dd"),
+            "address": self.address_edit.text(),
+            "phone": self.phone_edit.text(),
+            "register_date": self.register_edit.date().toString("yyyy-MM-dd"),
+            "last_visit_date": self.last_visit_edit.date().toString("yyyy-MM-dd"),
+            "referral": self.referral_edit.text(),
+            "medical_history": self.med_history.toPlainText(),
+            "extra_info": self.extra_info.toPlainText(),
+            "therapies": therapies,
+        }
+
+    def load_data(self, data: dict) -> None:
+        self.first_edit.setText(data.get("first_name", ""))
+        self.last_edit.setText(data.get("last_name", ""))
+        if data.get("birth_date"):
+            self.birth_edit.setDate(QDate.fromString(data["birth_date"], "yyyy-MM-dd"))
+        if data.get("register_date"):
+            self.register_edit.setDate(QDate.fromString(data["register_date"], "yyyy-MM-dd"))
+        if data.get("last_visit_date"):
+            self.last_visit_edit.setDate(QDate.fromString(data["last_visit_date"], "yyyy-MM-dd"))
+        self.address_edit.setText(data.get("address", ""))
+        self.phone_edit.setText(data.get("phone", ""))
+        self.referral_edit.setText(data.get("referral", ""))
+        self.med_history.setPlainText(data.get("medical_history", ""))
+        self.extra_info.setPlainText(data.get("extra_info", ""))
+        for t in data.get("therapies", []):
+            r = self.therapy_table.rowCount()
+            self.therapy_table.insertRow(r)
+            for c, key in enumerate(["visit_date", "tooth", "description", "payment", "cost", "discount", "comment"]):
+                self.therapy_table.setItem(r, c, QTableWidgetItem(str(t.get(key, ""))))
+        self._update_totals()
+

--- a/customers.py
+++ b/customers.py
@@ -11,11 +11,13 @@ from PySide6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QMessageBox,
-    QInputDialog,
     QFileDialog,
+    QCheckBox,
 )
 from PySide6.QtGui import QTextDocument
 from PySide6.QtPrintSupport import QPrinter
+
+from customer_dialog import CustomerDialog
 
 import database
 
@@ -35,6 +37,8 @@ class CustomersPage(QWidget):
         self.search_edit = QLineEdit()
         self.search_edit.setPlaceholderText("Search by name or phone ...")
         self.search_edit.textChanged.connect(self.search_customers)
+        self.balance_check = QCheckBox("Show Balance")
+        self.balance_check.stateChanged.connect(self.search_customers)
 
         add_btn = QPushButton("Add")
         add_btn.clicked.connect(self.add_customer)
@@ -53,9 +57,17 @@ class CustomersPage(QWidget):
         search_row.addWidget(edit_btn)
         search_row.addWidget(delete_btn)
         search_row.addWidget(pdf_btn)
+        search_row.addWidget(self.balance_check)
 
-        self.table = QTableWidget(0, 3)
-        self.table.setHorizontalHeaderLabels(["ID", "Name", "Phone"])
+        self.table = QTableWidget(0, 6)
+        self.table.setHorizontalHeaderLabels([
+            "ID",
+            "Name",
+            "Phone",
+            "Registered",
+            "Last Visit",
+            "Balance",
+        ])
         self.table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.table.setSelectionBehavior(QTableWidget.SelectRows)
 
@@ -65,8 +77,9 @@ class CustomersPage(QWidget):
 
     def load_customers(self, customers: list | None = None) -> None:
         """Populate table with customers."""
+        show_balance = self.balance_check.isChecked()
         if customers is None:
-            customers = database.get_all_customers()
+            customers = database.get_all_customers(show_balance)
         self.table.setRowCount(0)
         for row in customers:
             r = self.table.rowCount()
@@ -74,12 +87,17 @@ class CustomersPage(QWidget):
             self.table.setItem(r, 0, QTableWidgetItem(str(row["id"])))
             self.table.setItem(r, 1, QTableWidgetItem(row["name"]))
             self.table.setItem(r, 2, QTableWidgetItem(row["phone"] or ""))
+            self.table.setItem(r, 3, QTableWidgetItem(row.get("register_date", "")))
+            self.table.setItem(r, 4, QTableWidgetItem(row.get("last_visit_date", "")))
+            if show_balance:
+                self.table.setItem(r, 5, QTableWidgetItem(str(row["balance"])))
         if self.table.rowCount():
             self.table.resizeColumnsToContents()
 
     def search_customers(self) -> None:
         keyword = self.search_edit.text()
-        results = database.search_customers(keyword)
+        show_balance = self.balance_check.isChecked()
+        results = database.search_customers(keyword, show_balance)
         self.load_customers(results)
 
     def _selected_id(self) -> int | None:
@@ -90,29 +108,86 @@ class CustomersPage(QWidget):
         return int(item.text()) if item else None
 
     def add_customer(self) -> None:
-        name, ok = QInputDialog.getText(self, "Add Customer", "Name:")
-        if not ok or not name.strip():
-            return
-        phone, _ = QInputDialog.getText(self, "Add Customer", "Phone:")
-        database.add_customer(name.strip(), phone.strip())
-        self.search_customers()
+        dlg = CustomerDialog(parent=self)
+        if dlg.exec() == CustomerDialog.Accepted:
+            data = dlg.data()
+            cid = database.add_customer(
+                data["first_name"],
+                data["last_name"],
+                data["phone"],
+                data["address"],
+                data["birth_date"],
+                data["register_date"],
+                data["last_visit_date"],
+                data["referral"],
+                data["medical_history"],
+                data["extra_info"],
+            )
+            for t in data["therapies"]:
+                database.add_therapy(
+                    cid,
+                    t["visit_date"],
+                    t["tooth"],
+                    t["description"],
+                    t["payment"],
+                    t["cost"],
+                    t["discount"],
+                    t["comment"],
+                )
+            self.search_customers()
 
     def edit_customer(self) -> None:
         cid = self._selected_id()
         if cid is None:
             return
-        current_name = self.table.item(self.table.currentRow(), 1).text()
-        current_phone = self.table.item(self.table.currentRow(), 2).text()
-        name, ok = QInputDialog.getText(
-            self, "Edit Customer", "Name:", text=current_name
-        )
-        if not ok or not name.strip():
+        info = database.get_customer(cid)
+        if info is None:
             return
-        phone, _ = QInputDialog.getText(
-            self, "Edit Customer", "Phone:", text=current_phone
-        )
-        database.update_customer(cid, name.strip(), phone.strip())
-        self.search_customers()
+        therapies = list(database.get_therapies(cid))
+        data = {
+            "first_name": info["first_name"],
+            "last_name": info["last_name"],
+            "phone": info["phone"],
+            "address": info.get("address", ""),
+            "birth_date": info.get("birth_date", ""),
+            "register_date": info.get("register_date", ""),
+            "last_visit_date": info.get("last_visit_date", ""),
+            "referral": info.get("referral", ""),
+            "medical_history": info.get("medical_history", ""),
+            "extra_info": info.get("extra_info", ""),
+            "therapies": [dict(t) for t in therapies],
+        }
+        dlg = CustomerDialog(data, self)
+        if dlg.exec() == CustomerDialog.Accepted:
+            new = dlg.data()
+            database.update_customer(
+                cid,
+                new["first_name"],
+                new["last_name"],
+                new["phone"],
+                new["address"],
+                new["birth_date"],
+                new["register_date"],
+                new["last_visit_date"],
+                new["referral"],
+                new["medical_history"],
+                new["extra_info"],
+            )
+            # replace therapies
+            for t in database.get_therapies(cid):
+                database.delete_therapy(t["id"])
+            for t in new["therapies"]:
+                database.add_therapy(
+                    cid,
+                    t["visit_date"],
+                    t["tooth"],
+                    t["description"],
+                    t["payment"],
+                    t["cost"],
+                    t["discount"],
+                    t["comment"],
+                )
+            self.search_customers()
 
     def delete_customer(self) -> None:
         cid = self._selected_id()
@@ -133,10 +208,12 @@ class CustomersPage(QWidget):
         )
         if not path:
             return
-        customers = database.get_all_customers()
+        customers = database.get_all_customers(self.balance_check.isChecked())
         text = "<h1>Customers</h1><ul>"
         for c in customers:
-            text += f"<li>{c['name']} - {c['phone'] or ''}</li>"
+            bal = c.get('balance')
+            bal_text = f" - Owe: {bal}" if bal is not None else ""
+            text += f"<li>{c['name']} - {c['phone'] or ''}{bal_text}</li>"
         text += "</ul>"
         doc = QTextDocument()
         doc.setHtml(text)


### PR DESCRIPTION
## Summary
- add `customer_dialog` module for personal details and therapy entries
- extend database schema to store detailed customer information and therapies
- enhance customer table with balance toggle and register/visit dates
- implement add/edit dialogs with therapy management

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685ee2c44d388322afb93d3940c1df45