### PR TITLE
Modernize UI layout with responsive therapy tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ python main.py
 
 The application will create a local `data.db` SQLite database on first run.
 
+## UI Improvements
+
+The interface now features a modern dark theme and a sidebar layout with
+responsive tables. Therapy entries automatically resize so you no longer need
+to manually expand the tab when editing customers.
+

--- a/customer_dialog.py
+++ b/customer_dialog.py
@@ -14,6 +14,8 @@ from PySide6.QtWidgets import (
     QTableWidget,
     QTableWidgetItem,
     QWidget,
+    QHeaderView,
+    QSizePolicy,
 )
 from PySide6.QtCore import QDate
 
@@ -74,9 +76,11 @@ class CustomerDialog(QDialog):
             self.load_data(data)
 
     def _create_ui(self) -> None:
+        self.resize(700, 500)
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(6, 6, 6, 6)
+        layout.setContentsMargins(8, 8, 8, 8)
         self.tabs = QTabWidget()
+        self.tabs.setDocumentMode(True)
         layout.addWidget(self.tabs)
         # Personal tab
         personal = QWidget()
@@ -113,12 +117,15 @@ class CustomerDialog(QDialog):
         # Therapy tab
         therapy_tab = QWidget()
         t_layout = QVBoxLayout(therapy_tab)
+        t_layout.setContentsMargins(0, 0, 0, 0)
         self.therapy_table = QTableWidget(0, 7)
         self.therapy_table.setHorizontalHeaderLabels([
             "Date", "Tooth", "Description", "Payment", "Cost", "Discount", "Comment"
         ])
         self.therapy_table.verticalHeader().setVisible(False)
         self.therapy_table.horizontalHeader().setStretchLastSection(True)
+        self.therapy_table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.therapy_table.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.therapy_table.setAlternatingRowColors(True)
         t_layout.addWidget(self.therapy_table)
         add_btn = QPushButton("Add Entry")

--- a/customers.py
+++ b/customers.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QFileDialog,
     QCheckBox,
     QStyle,
+    QHeaderView,
 )
 from PySide6.QtGui import QTextDocument
 from PySide6.QtPrintSupport import QPrinter
@@ -33,7 +34,7 @@ class CustomersPage(QWidget):
 
     def _create_ui(self) -> None:
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(8, 8, 8, 8)
 
         search_row = QHBoxLayout()
         search_row.setSpacing(6)
@@ -77,6 +78,7 @@ class CustomersPage(QWidget):
         self.table.verticalHeader().setVisible(False)
         self.table.setAlternatingRowColors(True)
         self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.table.setStyleSheet(
             "QTableWidget { border: 1px solid #404040; }"
             "QHeaderView::section { background-color: #353535; font-weight: bold; }"

--- a/main.py
+++ b/main.py
@@ -57,7 +57,7 @@ class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Doctor App")
-        self.resize(800, 600)
+        self.resize(1024, 768)
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -68,9 +68,12 @@ class MainWindow(QMainWindow):
         root_layout.setContentsMargins(0, 0, 0, 0)
 
         # Sidebar with navigation buttons
-        sidebar = QVBoxLayout()
+        sidebar_widget = QWidget()
+        sidebar_widget.setFixedWidth(150)
+        sidebar = QVBoxLayout(sidebar_widget)
         sidebar.setSpacing(10)
-        root_layout.addLayout(sidebar)
+        sidebar.setContentsMargins(8, 8, 8, 8)
+        root_layout.addWidget(sidebar_widget)
 
         self.stack = QStackedWidget()
         root_layout.addWidget(self.stack, 1)


### PR DESCRIPTION
## Summary
- make customer table headers auto stretch
- modernize customer dialog with larger default size
- therapy table is now responsive with section resize mode and size policy
- adjust sidebar layout with fixed width
- document UI improvements in README

## Testing
- `python -m compileall -q customers.py database.py main.py customer_dialog.py dashboard.py reports.py settings.py`

------
https://chatgpt.com/codex/tasks/task_e_685eeac9881483229133d3fde0b59e7a